### PR TITLE
Mostly cleaning code a bit

### DIFF
--- a/Firmware/src/ntp_server.cpp
+++ b/Firmware/src/ntp_server.cpp
@@ -24,10 +24,10 @@ typedef struct
   ntp_flags_t flags;
   uint8_t stratum;         // Eight bits. Stratum level of the local clock.
   uint8_t poll;            // Eight bits. Maximum interval between successive messages.
-  uint8_t precision;       // Eight bits. Precision of the local clock.
+  int8_t  precision;       // Eight bits signed. Precision of the local clock.
 
   uint32_t rootDelay;      // 32 bits. Total round trip delay time.
-  uint32_t rootDispersion; // 32 bits. Max error aloud from primary clock source.
+  uint32_t rootDispersion; // 32 bits. Max error allowed from primary clock source.
   refID_t refId;           // 32 bits. Reference clock identifier.
    
 

--- a/Firmware/src/ntp_server.cpp
+++ b/Firmware/src/ntp_server.cpp
@@ -11,7 +11,7 @@ typedef struct{
     uint8_t vn:3;                 // vn.   Three bits. Version number of the protocol.
     uint8_t li:2;                 // li.   Two bits.   Leap indicator.
 }ntp_flags_t;
-  
+
 typedef union {
     uint32_t data;
     uint8_t byte[4];
@@ -29,7 +29,7 @@ typedef struct
   uint32_t rootDelay;      // 32 bits. Total round trip delay time.
   uint32_t rootDispersion; // 32 bits. Max error allowed from primary clock source.
   refID_t refId;           // 32 bits. Reference clock identifier.
-   
+
 
   uint32_t refTm_s;        // 32 bits. Reference time-stamp seconds.
   uint32_t refTm_f;        // 32 bits. Reference time-stamp fraction of a second.
@@ -43,7 +43,7 @@ typedef struct
   uint32_t txTm_s;         // 32 bits and the most important field the client cares about. Transmit time-stamp seconds.
   uint32_t txTm_f;         // 32 bits. Transmit time-stamp fraction of a second.
 
-} ntp_packet_t;    
+} ntp_packet_t;
 
 uint8_t __calloverhead = 0;
 
@@ -52,7 +52,7 @@ uint32_t(*fnc_read_utc)(void) = NULL;
 uint32_t(*fnc_read_subsecond)(void) = NULL;
 
 NTP_Server::NTP_Server( ){
-    
+
 }
 
 NTP_Server::~NTP_Server(){
@@ -75,14 +75,14 @@ uint8_t DeterminePrecision( void ){
       double runtime = ( ((double)(end)-(double)(start) ) / ( (double)(1000000.0) * (double)(1024) ) )+((double)(1)) ; // One second as we don't keep track on the fractions
       __calloverhead = log2(runtime);
 
-      
+
     } else {
       /* this is a bad one ! */
       configASSERT( fnc_read_utc != NULL );
     }
   return 0;
 
-    
+
 }
 
 bool NTP_Server::begin(uint16_t port , uint32_t(*fnc_getutc_time)(void) , uint32_t(*fnc_get_subsecond)(void) ){
@@ -118,11 +118,11 @@ void NTP_Server::processUDPPacket(AsyncUDPPacket& packet) {
            uint32_t processing_start = 0;
            uint32_t millisec = 0;
            ntp_packet_t ntp_req;
-           
+
           if(NULL != fnc_read_subsecond){
               millisec = fnc_read_subsecond();
           }
-           
+
 
            if(fnc_read_utc!=NULL){
               processing_start=fnc_read_utc()+NTP_TIMESTAMP_DELTA;
@@ -133,67 +133,37 @@ void NTP_Server::processUDPPacket(AsyncUDPPacket& packet) {
             /* this is not what we want ! */
             return;
            }
-           
-           memcpy(&ntp_req, packet.data(), sizeof(ntp_packet_t));
-           
-           /* Next is to swap the data arround */
-  
-          ntp_req.rootDelay = ntohl( ntp_req.rootDelay );    
-          ntp_req.rootDispersion = ntohl( ntp_req.rootDispersion );
-          ntp_req.refId.data = ntohl( ntp_req.refId.data );        
-        
-          ntp_req.refTm_s = ntohl(ntp_req.refTm_s );      
-          ntp_req.refTm_f = ntohl(ntp_req.refTm_f  );      
-         
-          ntp_req.origTm_s = ntohl( ntp_req.txTm_s );      
-          ntp_req.origTm_f = ntohl( ntp_req.txTm_f );                
 
-        
-          ntp_req.rxTm_s = ntohl( ntp_req.rxTm_s );        
-          ntp_req.rxTm_f = ntohl( ntp_req.rxTm_f );       
-        
-          ntp_req.txTm_s = ntohl( ntp_req.txTm_s );        
-          ntp_req.txTm_f = ntohl( ntp_req.txTm_f );       
+           memcpy(&ntp_req, packet.data(), sizeof(ntp_packet_t));
 
           ntp_req.flags.li = 0; //NONE
           ntp_req.flags.vn = 4; // NTP Version 4
           ntp_req.flags.mode = 4; // Server
+          ntp_req.stratum = 1;
+          // We don't touch ntp_req.poll
 
-          strncpy(ntp_req.refId.c_str ,"PPS", sizeof(ntp_req.refId.c_str) );
-          ntp_req.stratum = 1; 
-          // We don't touch ntp_req.poll 
           ntp_req.precision = __calloverhead;
-          ntp_req.rootDelay=1;      
-          ntp_req.rootDispersion=1; 
-          /* We don't touch the originate timestamp */
-
-          ntp_req.rxTm_s= processing_start;
-          ntp_req.rxTm_f= 0;
-          /* UNIX Start is 1.1.1970 and GPS Start is 1.1.1900 */ 
-          //ntp_req.refTm_s=  ntp_req.refTm_s +  NTP_TIMESTAMP_DELTA; // We need to add 70 Years
-          ntp_req.refTm_s = processing_start;
-          ntp_req.refTm_f = 0;
-          
-          ntp_req.txTm_s = fnc_read_utc()+NTP_TIMESTAMP_DELTA;
-          ntp_req.txTm_f = 0;  
-
-          ntp_req.rootDelay = htonl( ntp_req.rootDelay );    
+          ntp_req.rootDelay=1;
+          ntp_req.rootDispersion=1;
+          strncpy(ntp_req.refId.c_str ,"PPS", sizeof(ntp_req.refId.c_str) );
+          // Set to network byte order
+          ntp_req.rootDelay = htonl( ntp_req.rootDelay );
           ntp_req.rootDispersion = htonl( ntp_req.rootDispersion );
-        
-          ntp_req.refTm_s = htonl(ntp_req.refTm_s );      
-          ntp_req.refTm_f = htonl(ntp_req.refTm_f  );      
-          ntp_req.origTm_s = htonl( ntp_req.origTm_s );      
-          ntp_req.origTm_f = htonl( ntp_req.origTm_f );      
-        
-          ntp_req.rxTm_s = htonl( ntp_req.rxTm_s );        
-          //ntp_req.rxTm_f = htonl( ntp_req.rxTm_f );       
-          ntp_req.txTm_s = htonl( ntp_req.txTm_s ); 
-          ntp_req.rxTm_f = htonl(millisec * 4294967);  
+          ntp_req.refId.data = ntohl( ntp_req.refId.data );
+
+          ntp_req.origTm_s = ntp_req.txTm_s;
+          ntp_req.origTm_f = ntp_req.txTm_f;
+
+          ntp_req.rxTm_s = htonl(processing_start);
+          ntp_req.rxTm_f = htonl(millisec * 4294967);
+
+          ntp_req.refTm_s = ntp_req.rxTm_s;
+          ntp_req.refTm_f = ntp_req.rxTm_f;
+
+          /* UNIX Start is 1.1.1970 and GPS Start is 1.1.1900 */
+          ntp_req.txTm_s = fnc_read_utc()+NTP_TIMESTAMP_DELTA;  // We need to add 70 Years
+          ntp_req.txTm_s = htonl(ntp_req.txTm_s);
           ntp_req.txTm_f = htonl(millisec * 4294967);
 
-          ntp_req.txTm_f = htonl( ntp_req.txTm_f );   
-
           packet.write((uint8_t*)&ntp_req, sizeof(ntp_packet_t));
-        
-            
         }

--- a/Firmware/src/ntp_server.h
+++ b/Firmware/src/ntp_server.h
@@ -6,8 +6,9 @@ class NTP_Server {
 public:
     NTP_Server( );
     ~NTP_Server();
-    
+
     bool begin(uint16_t port , uint32_t(*fnc_getutc_time)(void) , uint32_t(*fnc_get_subsecond)(void) );
+private:    
     static void processUDPPacket(AsyncUDPPacket& packet);
       
 };

--- a/Firmware/src/webfunctions.cpp
+++ b/Firmware/src/webfunctions.cpp
@@ -34,22 +34,22 @@ extern gps_settings_t gps_config;
 
 /**************************************************************************************************
 *    Function      : response_settings
-*    Description   : Sends the timesettings as json 
+*    Description   : Sends the timesettings as json
 *    Input         : non
 *    Output        : none
 *    Remarks       : none
-**************************************************************************************************/ 
+**************************************************************************************************/
 void response_settings(){
 StaticJsonDocument<350> root;
 char strbuffer[129];
-String response="";  
-  
+String response="";
+
   memset(strbuffer,0,129);
   datum_t d = timec.GetLocalTimeDate();
   snprintf(strbuffer,64,"%02d:%02d:%02d",d.hour,d.minute,d.second);
-  
+
   root["time"] = strbuffer;
- 
+
   memset(strbuffer,0,129);
   snprintf(strbuffer,64,"%04d-%02d-%02d",d.year,d.month,d.day);
   root["date"] = strbuffer;
@@ -66,7 +66,7 @@ String response="";
   root["gps_sync"]=gps_config.sync_on_gps;
   //root["gps_baud"]=gps_config.baudrate;
   root["gps_rollovercnt"]=gps_config.rollover_cnt;
-  
+
   serializeJson(root, response);
   sendData(response);
 }
@@ -78,7 +78,7 @@ String response="";
 *    Input         : none
 *    Output        : none
 *    Remarks       : none
-**************************************************************************************************/ 
+**************************************************************************************************/
 void settime_update( ){ /* needs to process date and time */
   datum_t d;
   d.year=2000;
@@ -90,17 +90,17 @@ void settime_update( ){ /* needs to process date and time */
 
   bool time_found=false;
   bool date_found=false;
-  
+
   if( ! server->hasArg("date") || server->arg("date") == NULL ) { // If the POST request doesn't have username and password data
     /* we are missong something here */
   } else {
-   
+
     Serial.printf("found date: %s\n\r",server->arg("date").c_str());
     uint8_t d_len = server->arg("date").length();
     Serial.printf("datelen: %i\n\r",d_len);
     if(server->arg("date").length()!=10){
       Serial.println("date len failed");
-    } else {   
+    } else {
       String year=server->arg("date").substring(0,4);
       String month=server->arg("date").substring(5,7);
       String day=server->arg("date").substring(8,10);
@@ -108,34 +108,34 @@ void settime_update( ){ /* needs to process date and time */
       d.month = month.toInt();
       d.day = day.toInt();
       date_found=true;
-    }   
+    }
   }
 
   if( ! server->hasArg("time") || server->arg("time") == NULL ) { // If the POST request doesn't have username and password data
-    
+
   } else {
     if(server->arg("time").length()!=8){
       Serial.println("time len failed");
     } else {
-    
+
       String hour=server->arg("time").substring(0,2);
       String minute=server->arg("time").substring(3,5);
       String second=server->arg("time").substring(6,8);
       d.hour = hour.toInt();
       d.minute = minute.toInt();
-      d.second = second.toInt();     
+      d.second = second.toInt();
       time_found=true;
     }
-     
-  } 
+
+  }
   if( (time_found==true) && ( date_found==true) ){
     Serial.printf("Date: %i, %i, %i ", d.year , d.month, d.day );
     Serial.printf("Time: %i, %i, %i ", d.hour , d.minute, d.second );
     timec.SetLocalTime(d);
   }
-  
-  server->send(200);   
- 
+
+  server->send(200);
+
  }
 
 
@@ -145,29 +145,29 @@ void settime_update( ){ /* needs to process date and time */
 *    Input         : none
 *    Output        : none
 *    Remarks       : none
-**************************************************************************************************/  
+**************************************************************************************************/
 void timezone_update( ){ /*needs to handel timezoneid */
   if( ! server->hasArg("timezoneid") || server->arg("timezoneid") == NULL ) { // If the POST request doesn't have username and password data
     /* we are missong something here */
   } else {
-   
+
     Serial.printf("New TimeZoneID: %s\n\r",server->arg("timezoneid").c_str());
     uint32_t timezoneid = server->arg("timezoneid").toInt();
-    timec.SetTimeZone( (TIMEZONES_NAMES_t)timezoneid );   
+    timec.SetTimeZone( (TIMEZONES_NAMES_t)timezoneid );
   }
   timec.SaveConfig();
-  server->send(200);    
+  server->send(200);
 
  }
 
- 
+
 /**************************************************************************************************
 *    Function      : timezone_overrides_update
 *    Description   : Parses POST for new timzone overrides
 *    Input         : none
 *    Output        : none
 *    Remarks       : none
-**************************************************************************************************/  
+**************************************************************************************************/
  void timezone_overrides_update( ){ /* needs to handle DLSOverrid,  ManualDLS, dls_offset, ZONE_OVERRRIDE and GMT_OFFSET */
 
   bool DLSOverrid=false;
@@ -178,19 +178,19 @@ void timezone_update( ){ /*needs to handel timezoneid */
   if( ! server->hasArg("dlsdis") || server->arg("dlsdis") == NULL ) { // If the POST request doesn't have username and password data
       /* we are missing something here */
   } else {
-    DLSOverrid=true;  
+    DLSOverrid=true;
   }
 
   if( ! server->hasArg("dlsmanena") || server->arg("dlsmanena") == NULL ) { // If the POST request doesn't have username and password data
       /* we are missing something here */
   } else {
-    ManualDLS=true;  
+    ManualDLS=true;
   }
 
   if( ! server->hasArg("ZONE_OVERRRIDE") || server->arg("ZONE_OVERRRIDE") == NULL ) { // If the POST request doesn't have username and password data
       /* we are missing something here */
   } else {
-    ZONE_OVERRRIDE=true;  
+    ZONE_OVERRRIDE=true;
   }
 
   if( ! server->hasArg("gmtoffset") || server->arg("gmtoffset") == NULL ) { // If the POST request doesn't have username and password data
@@ -210,11 +210,11 @@ void timezone_update( ){ /*needs to handel timezoneid */
   timec.SetManualDLSEna(ManualDLS);
   timec.SetTimeZoneManual(ZONE_OVERRRIDE);
 
- 
-  timec.SaveConfig();
-  server->send(200);    
 
-  
+  timec.SaveConfig();
+  server->send(200);
+
+
  }
 
 
@@ -232,13 +232,13 @@ void timezone_update( ){ /*needs to handel timezoneid */
 *    Input         : none
 *    Output        : none
 *    Remarks       : none
-**************************************************************************************************/ 
+**************************************************************************************************/
 void update_notes(){
   char data[501]={0,};
   if( ! server->hasArg("notes") || server->arg("notes") == NULL ) { // If the POST request doesn't have username and password data
     /* we are missing something here */
   } else {
-   
+
     Serial.printf("New Notes: %s\n\r",server->arg("notes").c_str());
     /* direct commit */
     uint32_t str_size = server->arg("notes").length();
@@ -250,7 +250,7 @@ void update_notes(){
     }
   }
 
-  server->send(200);    
+  server->send(200);
 }
 
 /**************************************************************************************************
@@ -259,27 +259,27 @@ void update_notes(){
 *    Input         : none
 *    Output        : none
 *    Remarks       : Retunrs the notes as plain text
-**************************************************************************************************/ 
+**************************************************************************************************/
 void read_notes(){
   char data[501]={0,};
   eepread_notes((uint8_t*)data,501);
-  sendData(data);    
+  sendData(data);
 }
 
 
 /**************************************************************************************************
 *    Function      : getipv4settings_settings
-*    Description   : Sends the ipv4 settings as json 
+*    Description   : Sends the ipv4 settings as json
 *    Input         : non
 *    Output        : none
 *    Remarks       : none
-**************************************************************************************************/ 
+**************************************************************************************************/
 void getipv4settings_settings(){
 StaticJsonDocument<2048> doc;
-String response="";  
+String response="";
 
 ipv4_settings s = read_ipv4_settings();
-  
+
   doc["USE_STATIC"] = s.use_static;
 
   JsonArray IP = doc.createNestedArray("IP");
@@ -287,25 +287,25 @@ ipv4_settings s = read_ipv4_settings();
   IP.add(  (uint8_t)( ( s.address >> 8) & 0xFF) );
   IP.add(  (uint8_t)( ( s.address >> 16) & 0xFF) );
   IP.add(  (uint8_t)( ( s.address >> 24) & 0xFF) );
-  
+
   JsonArray SUBNET = doc.createNestedArray("SUBNET");
   SUBNET.add( (uint8_t)( ( s.subnet >> 0) & 0xFF));
   SUBNET.add( (uint8_t)( ( s.subnet >> 8) & 0xFF));
   SUBNET.add( (uint8_t)( ( s.subnet >> 16) & 0xFF));
   SUBNET.add( (uint8_t)( ( s.subnet >> 24) & 0xFF));
-  
+
   JsonArray GATEWAY = doc.createNestedArray("GATEWAY");
   GATEWAY.add( (uint8_t)( ( s.gateway >> 0) & 0xFF));
   GATEWAY.add( (uint8_t)( ( s.gateway >> 8) & 0xFF));
   GATEWAY.add( (uint8_t)( ( s.gateway >> 16) & 0xFF));
   GATEWAY.add( (uint8_t)( ( s.gateway >> 24) & 0xFF));
-  
+
   JsonArray DNS0 = doc.createNestedArray("DNS0");
   DNS0.add( (uint8_t)( ( s.dns0 >> 0) & 0xFF));
   DNS0.add( (uint8_t)( ( s.dns0 >> 8) & 0xFF));
   DNS0.add( (uint8_t)( ( s.dns0 >> 16) & 0xFF));
   DNS0.add( (uint8_t)( ( s.dns0 >> 24) & 0xFF));
-  
+
   JsonArray DNS1 = doc.createNestedArray("DNS1");
   DNS1.add( (uint8_t)( ( s.dns1 >> 0) & 0xFF));
   DNS1.add( (uint8_t)( ( s.dns1 >> 8) & 0xFF));
@@ -324,7 +324,7 @@ ipv4_settings s = read_ipv4_settings();
 *    Input         : none
 *    Output        : none
 *    Remarks       : Retunrs the GPS location
-**************************************************************************************************/ 
+**************************************************************************************************/
 void getGPS_Location(){
 String response;
 const size_t capacity = JSON_ARRAY_SIZE(2) + JSON_OBJECT_SIZE(3);
@@ -345,7 +345,7 @@ DynamicJsonDocument  root(capacity);
   data.add(gps.location.lng());
   serializeJson(root, response);
   sendData(response);
-  
+
 }
 
 /**************************************************************************************************
@@ -356,17 +356,17 @@ DynamicJsonDocument  root(capacity);
 *    Remarks       : none
 **************************************************************************************************/
 void update_gps_syncclock( void ){
-  if( ! server->hasArg("GPS_SYNC_ON") || server->arg("GPS_SYNC_ON") == NULL ) { 
+  if( ! server->hasArg("GPS_SYNC_ON") || server->arg("GPS_SYNC_ON") == NULL ) {
     /* we are missing something here */
     gps_config.sync_on_gps = false;
   } else {
     gps_config.sync_on_gps = true;
-   /* Enable Sync on GPS */  
+   /* Enable Sync on GPS */
   }
 
 /*
- if( ! server->hasArg("GPS_BAUD") || server->arg("GPS_BAUD") == NULL ) { 
-     gps_config.baudrate=gps_config.baudrate; 
+ if( ! server->hasArg("GPS_BAUD") || server->arg("GPS_BAUD") == NULL ) {
+     gps_config.baudrate=gps_config.baudrate;
   } else {
     int32_t br = server->arg("GPS_BAUD").toInt();
     if(br>0){
@@ -374,15 +374,15 @@ void update_gps_syncclock( void ){
     } else {
       gps_config.baudrate=9600;
     }
-  } 
+  }
 */
-  if( ! server->hasArg("GPS_ROLLOVERCNT") || server->arg("GPS_ROLLOVERCNT") == NULL ) { 
+  if( ! server->hasArg("GPS_ROLLOVERCNT") || server->arg("GPS_ROLLOVERCNT") == NULL ) {
     /* we are missing something here */
      gps_config.rollover_cnt = gps_config.rollover_cnt;
   } else {
     int32_t roc = server->arg("GPS_ROLLOVERCNT").toInt();
     if(roc>=0){
-      
+
       gps_config.rollover_cnt=roc;
       Serial.printf("Set rollover coutn to %i\n\r", gps_config.rollover_cnt);
     } else {
@@ -390,13 +390,13 @@ void update_gps_syncclock( void ){
       gps_config.rollover_cnt=0;
     }
 
-  
-  } 
+
+  }
 
 
 
   write_gps_config((gps_settings_t)(gps_config));
-  server->send(200);   
+  server->send(200);
 
 }
 
@@ -419,10 +419,10 @@ void update_display_settings( void ){
     } else {
       disp_config.swap_display = false;
     }
-   /* Enable Swap */  
-  }  
+   /* Enable Swap */
+  }
   write_display_config(disp_config);
-  server->send(200);   
+  server->send(200);
 
 }
 
@@ -434,24 +434,24 @@ void update_ipv4_settings( void ){
       /* we are missing something here */
       Serial.println("JSON Print missing");
   } else {
-    
+
 
 
 
  if(server->arg("JSON").length() < 2048 ){ /* we only process messages up to 2048 elements */
   DynamicJsonDocument doc(2048);
- 
-  if(0 != deserializeJson(doc, server->arg("JSON" ) ) ){
+
+  if (deserializeJson(doc, server->arg("JSON" ) ) ){
     Serial.println("JSON deserilize failed");
-    server->send(200);  
+    server->send(200);
     return;
   }
-   
+
     bool USE_STATIC = doc["USE_STATIC"];
     s.use_static = USE_STATIC;
     Serial.print("Static Mode=");
     Serial.println(USE_STATIC);
-    
+
     JsonArray  IP = doc["IP"];
     if( (IP.isNull() != true)  ){
       uint8_t IP_0 = IP[0]; // 192
@@ -464,8 +464,8 @@ void update_ipv4_settings( void ){
       Serial.println(IP_ADR);
       s.address = addr;
     }
-      
-    
+
+
 
     JsonArray  SUBNET = doc["SUBNET"];
     if( (SUBNET.isNull() != true)  ){
@@ -485,7 +485,7 @@ void update_ipv4_settings( void ){
       uint8_t GATEWAY_0 = GATEWAY[0]; // 192
       uint8_t GATEWAY_1 = GATEWAY[1]; // 168
       uint8_t GATEWAY_2 = GATEWAY[2]; // 0
-      uint8_t GATEWAY_3 = GATEWAY[3]; // 1  
+      uint8_t GATEWAY_3 = GATEWAY[3]; // 1
       uint32_t gateway = ( GATEWAY_0 << 0 ) | ( GATEWAY_1 << 8 ) | ( GATEWAY_2 << 16 ) | ( GATEWAY_3 << 24 ) ;
       IPAddress GATEWAY_ADR(gateway);
       Serial.print("New GATEWAY:");
@@ -498,7 +498,7 @@ void update_ipv4_settings( void ){
       uint8_t DNS0_0 = DNS0[0]; // 192
       uint8_t DNS0_1 = DNS0[1]; // 168
       uint8_t DNS0_2 = DNS0[2]; // 0
-      uint8_t DNS0_3 = DNS0[3]; // 1  
+      uint8_t DNS0_3 = DNS0[3]; // 1
       uint32_t dns0 = ( DNS0_0 << 0 ) | ( DNS0_1 << 8 ) | ( DNS0_2 << 16 ) | ( DNS0_3 << 24 ) ;
       IPAddress DNS_ADR(dns0);
       Serial.print("New DNS0:");
@@ -508,27 +508,27 @@ void update_ipv4_settings( void ){
 
     JsonArray  DNS1 = doc["DNS1"];
     if( (DNS1.isNull() != true) ){
-    
+
       uint8_t DNS1_0 = DNS1[0]; // 192
       uint8_t DNS1_1 = DNS1[1]; // 168
       uint8_t DNS1_2 = DNS1[2]; // 0
       uint8_t DNS1_3 = DNS1[3]; // 1
-      uint32_t dns1 = ( DNS1_0 << 0 ) | ( DNS1_1 << 8 ) | ( DNS1_2 << 16 ) | ( DNS1_3 << 24 ) ;  
+      uint32_t dns1 = ( DNS1_0 << 0 ) | ( DNS1_1 << 8 ) | ( DNS1_2 << 16 ) | ( DNS1_3 << 24 ) ;
       IPAddress DNS_ADR(dns1);
-      s.dns1 = dns1;          
+      s.dns1 = dns1;
       Serial.print("New DNS1:");
       Serial.println(DNS_ADR);
     }
-  
+
   }else {
     Serial.println("JSON to long");
   }
 
   // We print the new settings and save them
   write_ipv4_settings(s);
-  } 
-  server->send(200);  
-  
+  }
+  server->send(200);
+
 }
 /**************************************************************************************************
 *    Function      : send_display_settings
@@ -542,7 +542,7 @@ void send_display_settings( void ){
   String response ="";
   const size_t capacity = JSON_ARRAY_SIZE(2) + JSON_OBJECT_SIZE(3);
   DynamicJsonDocument  root(capacity);
-  
+
   root["swap_display"] = disp_config.swap_display;
   serializeJson(root, response);
   sendData(response);


### PR DESCRIPTION
Proposed changes to NTP_Server
 - 53fa221: ntp_packet_t.precision is a signed byte and usually negative.
 - 138f945: can't imagine processUDPPacket() would ever need to be called from outside the NTP_Server.
 - 725ae69: removing the initial byte order swaps of the timestamps that get overwritten later.

Compilation error in platform-espressif32 v 6.3.1
  - c23def7: compiler throwing error when comparing 0 to deserializeJson in line 443
  - all the other changes are fluff; my editor automatically removed trailing spaces. Sorry about that.

**Thank you very much for NTP_Server, it is very useful.**